### PR TITLE
ghcup: bootstrap with cabal config modified

### DIFF
--- a/ghcup/sync.sh
+++ b/ghcup/sync.sh
@@ -9,6 +9,8 @@ mkdir -p "$TO/sh"
 pushd "$TO/sh"
 curl https://raw.githubusercontent.com/haskell/ghcup-hs/master/scripts/bootstrap/bootstrap-haskell -o bootstrap-haskell
 sed -i 's|https://downloads.haskell.org/~ghcup|https://mirrors.ustc.edu.cn/ghcup/downloads.haskell.org/~ghcup|' bootstrap-haskell
+sed -i '/edo cabal update/ i \ \ \ \ edo cabal user-config update -a "repository mirrors.ustc.edu.cn" -a "  url: https://mirrors.ustc.edu.cn/hackage/" ' bootstrap-haskell
+# make ghcup init cabal config before cabal update
 curl https://raw.githubusercontent.com/haskell/ghcup-hs/master/scripts/bootstrap/bootstrap-haskell.ps1 -o bootstrap-haskell.ps1
 sed -i 's|https://www.haskell.org/ghcup/sh/bootstrap-haskell|https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell|' bootstrap-haskell.ps1
 sed -i 's|https://repo.msys2.org/distrib/|https://mirrors.ustc.edu.cn/msys2/distrib/|' bootstrap-haskell.ps1


### PR DESCRIPTION
### Checklist

- [ ] 更新 README

During the installation of cabal,
GHCup would update cabal as soon as it's installed;
But at that point, Cabal config is not adjusted to ustcmirror.
We add a logic to addjust cabal config before cabal updating.

我的疑虑是，
这样的对脚本进行的`插入一行命令`式的更新是否会对可维护性造成破坏